### PR TITLE
api: Serialize the writing of a frame.

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -3,7 +3,7 @@
 script_dir=$(cd `dirname $0`; pwd)
 root_dir=`dirname $script_dir`
 
-test_packages="."
+test_packages=". ./api"
 go_test_flags="-v -race -timeout 2s"
 
 echo Running go test on packages "'$test_packages'" with flags "'$go_test_flags'"

--- a/api/payload.go
+++ b/api/payload.go
@@ -26,12 +26,9 @@ import (
 // console. The proxy can output this data when asked for verbose output.
 //
 //  {
-//    "id": "registerVM",
-//    "data": {
-//      "containerId": "756535dc6e9ab9b560f84c8...",
-//      "ctlSerial": "/tmp/sh.hyper.channel.0.sock",
-//      "ioSerial": "/tmp/sh.hyper.channel.1.sock"
-//    }
+//   "containerId": "756535dc6e9ab9b560f84c8...",
+//   "ctlSerial": "/tmp/sh.hyper.channel.0.sock",
+//   "ioSerial": "/tmp/sh.hyper.channel.1.sock"
 //  }
 type RegisterVM struct {
 	ContainerID string `json:"containerId"`
@@ -43,10 +40,7 @@ type RegisterVM struct {
 // RegisterVMResponse is the result from a successful RegisterVM.
 //
 //  {
-//    "success": true,
-//    "data": {
-//      "version": 1
-//    }
+//    "version": 1
 //  }
 type RegisterVMResponse struct {
 	// The version of the proxy protocol
@@ -58,10 +52,7 @@ type RegisterVMResponse struct {
 // issued beforehand.
 //
 //  {
-//    "id": "attach",
-//    "data": {
-//      "containerId": "756535dc6e9ab9b560f84c8..."
-//    }
+//    "containerId": "756535dc6e9ab9b560f84c8..."
 //  }
 type AttachVM struct {
 	ContainerID string `json:"containerId"`
@@ -70,13 +61,10 @@ type AttachVM struct {
 // AttachVMResponse is the result from a successful AttachVM.
 //
 //  {
-//    "success": true,
-//    "data": {
-//      "version": 1
-//    }
+//    "version": 1
 //  }
 type AttachVMResponse struct {
-	// The version of the proxy protocol
+	// Version is the version of the proxy protocol.
 	Version int `json:"version"`
 }
 
@@ -85,10 +73,7 @@ type AttachVMResponse struct {
 // for the container identified by containerId.
 //
 //  {
-//    "id": "unregister",
-//    "data": {
-//      "containerId": "756535dc6e9ab9b560f84c8..."
-//    }
+//    "containerId": "756535dc6e9ab9b560f84c8..."
 //  }
 type UnregisterVM struct {
 	ContainerID string `json:"containerId"`
@@ -110,4 +95,9 @@ type UnregisterVM struct {
 type Hyper struct {
 	HyperName string          `json:"hyperName"`
 	Data      json.RawMessage `json:"data,omitempty"`
+}
+
+// ErrorResponse is the payload send in Responses where the Error flag is set.
+type ErrorResponse struct {
+	Message string `json:"msg"`
 }

--- a/api/protocol_test.go
+++ b/api/protocol_test.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// hl is in bytes
+func makeFrame(v, hl int, t FrameType, op, pl int) []byte {
+	buf := make([]byte, hl+pl)
+	binary.BigEndian.PutUint16(buf[0:2], uint16(v))
+	buf[2] = byte(hl / 4)
+	buf[6] = byte(t)
+	buf[7] = byte(op)
+	binary.BigEndian.PutUint32(buf[8:8+4], uint32(pl))
+
+	return buf
+}
+
+func setFlags(data []byte, flags uint8) {
+	b := data[6]
+	b |= flags
+	data[6] = b
+}
+
+func getFlags(data []byte) uint8 {
+	return data[6] & 0xf0
+}
+
+func makeStreamFrame(v, hl int, op Stream, pl int) []byte {
+	return makeFrame(v, hl, TypeStream, int(op), pl)
+}
+
+func makeFrameReader(t FrameType, op, pl int) io.Reader {
+	frame := makeFrame(Version, minHeaderLength, t, op, pl)
+	return bytes.NewReader(frame)
+}
+
+func TestReadFrame(t *testing.T) {
+	reader := makeFrameReader(TypeStream, int(StreamStderr), 1024)
+	frame, err := ReadFrame(reader)
+	assert.Nil(t, err)
+
+	header := &frame.Header
+	assert.Equal(t, Version, header.Version)
+	assert.Equal(t, minHeaderLength, header.HeaderLength)
+	assert.Equal(t, TypeStream, FrameType(header.Type))
+	assert.Equal(t, StreamStderr, Stream(header.Opcode))
+	assert.Equal(t, 1024, header.PayloadLength)
+	assert.Equal(t, 1024, len(frame.Payload))
+}
+
+func TestReadFrameFlags(t *testing.T) {
+	buf := makeFrame(Version, minHeaderLength, TypeResponse, int(CmdSignal), 16)
+	setFlags(buf, flagInError)
+	r := bytes.NewReader(buf)
+	frame, err := ReadFrame(r)
+	assert.Nil(t, err)
+	assert.Equal(t, true, frame.Header.InError)
+}
+
+func TestReadFrameErrorPaths(t *testing.T) {
+	// EOF.
+	frame, err := ReadFrame(bytes.NewReader(nil))
+	assert.Nil(t, frame)
+	assert.NotNil(t, err)
+
+	// Truncated input, header too short.
+	buf := makeStreamFrame(Version, minHeaderLength, StreamStderr, 1024)
+	frame, err = ReadFrame(bytes.NewReader(buf[0:10]))
+	assert.Nil(t, frame)
+	assert.NotNil(t, err)
+
+	// Truncated input, payload too short.
+	buf = makeStreamFrame(Version, minHeaderLength, StreamStderr, 1024)
+	frame, err = ReadFrame(bytes.NewReader(buf[0:512]))
+	assert.Nil(t, frame)
+	assert.NotNil(t, err)
+
+	// Bad version
+	buf = makeStreamFrame(0x8fff, minHeaderLength, StreamStderr, 1024)
+	frame, err = ReadFrame(bytes.NewReader(buf))
+	assert.Nil(t, frame)
+	assert.NotNil(t, err)
+
+	buf = makeStreamFrame(0, minHeaderLength, StreamStderr, 1024)
+	frame, err = ReadFrame(bytes.NewReader(buf))
+	assert.Nil(t, frame)
+	assert.NotNil(t, err)
+
+	// Bad type
+	buf = makeFrame(Version, minHeaderLength, TypeMax, 0, 1024)
+	frame, err = ReadFrame(bytes.NewReader(buf))
+	assert.Nil(t, frame)
+	assert.NotNil(t, err)
+}
+
+// TestLargerHeader makes sure we can read a larger header than minHeaderLength
+// without any issue.
+func TestReadFrameLargerHeader(t *testing.T) {
+	buf := makeFrame(Version, minHeaderLength+12, TypeStream,
+		int(StreamStderr), 1024)
+	frame, err := ReadFrame(bytes.NewReader(buf))
+	assert.Nil(t, err)
+
+	header := &frame.Header
+	assert.Equal(t, Version, header.Version)
+	assert.Equal(t, minHeaderLength+12, header.HeaderLength)
+	assert.Equal(t, TypeStream, FrameType(header.Type))
+	assert.Equal(t, StreamStderr, Stream(header.Opcode))
+	assert.Equal(t, 1024, header.PayloadLength)
+	assert.Equal(t, 1024, len(frame.Payload))
+}
+
+func newBuffer(payloadLength int) *bytes.Buffer {
+	buf := make([]byte, 0, minHeaderLength+payloadLength)
+	return bytes.NewBuffer(buf)
+}
+
+func newTestFrame(t FrameType, op, pl int) *Frame {
+	payload := make([]byte, pl)
+	for i := range payload {
+		payload[i] = 0xaa
+	}
+
+	return NewFrame(t, op, payload)
+}
+
+func newStreamFrame(op Stream, pl int) *Frame {
+	return newTestFrame(TypeStream, int(op), pl)
+}
+
+func newCommandFrame(op Stream, pl int) *Frame {
+	return newTestFrame(TypeStream, int(op), pl)
+}
+
+func newResponseFrame(op Stream, pl int) *Frame {
+	return newTestFrame(TypeStream, int(op), pl)
+}
+
+func TestWriteFrame(t *testing.T) {
+	w := newBuffer(1024)
+	frame := newStreamFrame(StreamStderr, 1024)
+
+	err := WriteFrame(w, frame)
+	assert.Nil(t, err)
+	buf := w.Bytes()
+
+	version := int(binary.BigEndian.Uint16(buf[0:2]))
+	assert.Equal(t, Version, version)
+	assert.Equal(t, uint8(minHeaderLength/4), buf[2])
+	assert.Equal(t, byte(TypeStream), buf[6]&0xf)
+	assert.Equal(t, byte(StreamStderr), buf[7])
+	pl := int(binary.BigEndian.Uint32(buf[8 : 8+4]))
+	assert.Equal(t, 1024, pl)
+
+	for i := range buf[minHeaderLength : minHeaderLength+1024] {
+		assert.Equal(t, uint8(0xaa), buf[minHeaderLength+i])
+	}
+}
+
+func TestWriteFrameFlags(t *testing.T) {
+	frame := newStreamFrame(StreamStderr, 1024)
+	frame.Header.InError = true
+
+	w := newBuffer(1024)
+	err := WriteFrame(w, frame)
+	assert.Nil(t, err)
+	buf := w.Bytes()
+	assert.Equal(t, uint8(flagInError), getFlags(buf))
+}
+
+func TestWriteFrameErrorPaths(t *testing.T) {
+	// Header.PayloadLength to large compared to len(Payload.)
+	w := newBuffer(1024)
+	frame := newStreamFrame(StreamStderr, 1024)
+	frame.Header.PayloadLength = 1025
+
+	err := WriteFrame(w, frame)
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, w.Len())
+}
+
+func TestWriteCommand(t *testing.T) {
+	w := newBuffer(1024)
+	err := WriteCommand(w, CmdSignal, nil)
+	assert.Nil(t, err)
+
+	buf := w.Bytes()
+	assert.Equal(t, byte(TypeCommand), buf[6]&0xf)
+}
+
+func TestWriteResponse(t *testing.T) {
+	w := newBuffer(1024)
+	err := WriteResponse(w, CmdSignal, false, nil)
+	assert.Nil(t, err)
+
+	buf := w.Bytes()
+	assert.Equal(t, byte(TypeResponse), buf[6]&0xf)
+}
+
+func TestWriteStream(t *testing.T) {
+	w := newBuffer(1024)
+	err := WriteStream(w, StreamStderr, nil)
+	assert.Nil(t, err)
+
+	buf := w.Bytes()
+	assert.Equal(t, byte(TypeStream), buf[6]&0xf)
+}
+
+func TestWriteNotification(t *testing.T) {
+	w := newBuffer(1024)
+	err := WriteNotification(w, NotificationProcessExited, nil)
+	assert.Nil(t, err)
+
+	buf := w.Bytes()
+	assert.Equal(t, byte(TypeNotification), buf[6]&0xf)
+}

--- a/protocol.go
+++ b/protocol.go
@@ -51,17 +51,15 @@ func (r *handlerResponse) AddResult(key string, value interface{}) {
 }
 
 type protocol struct {
-	handlers map[string]protocolHandler
+	cmdHandlers [api.CmdMax]protocolHandler
 }
 
 func newProtocol() *protocol {
-	return &protocol{
-		handlers: make(map[string]protocolHandler),
-	}
+	return &protocol{}
 }
 
-func (proto *protocol) Handle(cmd string, handler protocolHandler) {
-	proto.handlers[cmd] = handler
+func (proto *protocol) Handle(cmd api.Command, handler protocolHandler) {
+	proto.cmdHandlers[cmd] = handler
 }
 
 type clientCtx struct {
@@ -70,35 +68,45 @@ type clientCtx struct {
 	userData interface{}
 }
 
-func (proto *protocol) handleRequest(ctx *clientCtx, req *api.Request, hr *handlerResponse) *api.Response {
-	if req.ID == "" {
-		return &api.Response{
-			Success: false,
-			Error:   "no 'id' field in request",
-		}
+func newErrorResponse(opcode int, errMsg string) *api.Frame {
+	frame, err := api.NewFrameJSON(api.TypeResponse, opcode, &api.ErrorResponse{
+		Message: errMsg,
+	})
+	if err != nil {
+		frame, err = api.NewFrameJSON(api.TypeResponse, opcode, &api.ErrorResponse{
+			Message: fmt.Sprintf("couldn't marshal response: %v", err),
+		})
+	}
+	if err != nil {
+		frame = api.NewFrame(api.TypeResponse, opcode, nil)
 	}
 
-	handler, ok := proto.handlers[req.ID]
-	if !ok {
-		return &api.Response{
-			Success: false,
-			Error:   fmt.Sprintf("no payload named '%s'", req.ID),
-		}
-	}
+	frame.Header.InError = true
 
-	handler(req.Data, ctx.userData, hr)
+	return frame
+}
+
+func (proto *protocol) handleCommand(ctx *clientCtx, cmd *api.Frame) *api.Frame {
+	hr := handlerResponse{}
+
+	// cmd.Header.Opcode is guaranteed to be within the right bounds by
+	// ReadFrame().
+	handler := proto.cmdHandlers[cmd.Header.Opcode]
+
+	handler(cmd.Payload, ctx.userData, &hr)
 	if hr.err != nil {
-		return &api.Response{
-			Success: false,
-			Error:   hr.err.Error(),
-			Data:    hr.results,
-		}
+		return newErrorResponse(cmd.Header.Opcode, hr.err.Error())
 	}
 
-	return &api.Response{
-		Success: true,
-		Data:    hr.results,
+	var payload interface{}
+	if len(hr.results) > 0 {
+		payload = hr.results
 	}
+	frame, err := api.NewFrameJSON(api.TypeResponse, cmd.Header.Opcode, payload)
+	if err != nil {
+		return newErrorResponse(cmd.Header.Opcode, err.Error())
+	}
+	return frame
 }
 
 func (proto *protocol) Serve(conn net.Conn, userData interface{}) error {
@@ -108,22 +116,25 @@ func (proto *protocol) Serve(conn net.Conn, userData interface{}) error {
 	}
 
 	for {
-		// Parse a request.
-		req := api.Request{}
-		hr := handlerResponse{}
 
-		err := api.ReadMessage(conn, &req)
+		frame, err := api.ReadFrame(conn)
 		if err != nil {
 			// EOF or the client isn't even sending proper JSON,
 			// just kill the connection
 			return err
 		}
+		if frame.Header.Type != api.TypeCommand {
+			// EOF or the client isn't even sending proper JSON,
+			// just kill the connection
+			return fmt.Errorf("serve: expected a command got a %v", frame.Header.Type)
+
+		}
 
 		// Execute the corresponding handler
-		resp := proto.handleRequest(ctx, &req, &hr)
+		resp := proto.handleCommand(ctx, frame)
 
 		// Send the response back to the client.
-		if err = api.WriteMessage(conn, resp); err != nil {
+		if err = api.WriteFrame(conn, resp); err != nil {
 			// Something made us unable to write the response back
 			// to the client (could be a disconnection, ...).
 			return err

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -15,15 +15,16 @@
 package main
 
 import (
-	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net"
 	"os"
 	"sync"
 	"testing"
+
+	"github.com/clearcontainers/proxy/api"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -72,56 +73,6 @@ func setupMockServer(t *testing.T, proto *protocol) (client net.Conn, server *mo
 	return client, server
 }
 
-// Low level read/write (header + data)
-const headerLength = 8 // bytes
-
-func writeMessage(writer io.Writer, data []byte) error {
-	buf := make([]byte, headerLength)
-	binary.BigEndian.PutUint32(buf[0:4], uint32(len(data)))
-	n, err := writer.Write(buf)
-	if err != nil {
-		return err
-	}
-	if n != headerLength {
-		return errors.New("couldn't write the full header")
-	}
-
-	n, err = writer.Write(data)
-	if err != nil {
-		return err
-	}
-	if n != len(data) {
-		return errors.New("couldn't write the full data")
-	}
-
-	return nil
-}
-
-func readMessage(reader io.Reader) ([]byte, error) {
-	buf := make([]byte, headerLength)
-	n, err := reader.Read(buf)
-	if err != nil {
-		return nil, err
-	}
-	if n != headerLength {
-		return nil, errors.New("couldn't read the full header")
-	}
-
-	received := 0
-	need := int(binary.BigEndian.Uint32(buf[0:4]))
-	data := make([]byte, need)
-	for received < need {
-		n, err := reader.Read(data[received:need])
-		if err != nil {
-			return nil, err
-		}
-
-		received += n
-	}
-
-	return data, nil
-}
-
 // Test that we correctly give back the user data to handlers
 type myUserData struct {
 	t  *testing.T
@@ -139,7 +90,7 @@ func userDataHandler(data []byte, userData interface{}, response *handlerRespons
 
 func TestUserData(t *testing.T) {
 	proto := newProtocol()
-	proto.Handle("foo", userDataHandler)
+	proto.Handle(api.Command(0), userDataHandler)
 
 	server := newMockServer(t, proto)
 	client := server.GetClientConn()
@@ -147,7 +98,7 @@ func TestUserData(t *testing.T) {
 	go server.ServeWithUserData(&testUserData)
 
 	testUserData.wg.Add(1)
-	err := writeMessage(client, []byte(`{ "id": "foo" }`))
+	err := api.WriteCommand(client, api.Command(0), nil)
 	assert.Nil(t, err)
 
 	// make sure the handler runs by waiting for it
@@ -166,6 +117,7 @@ func echoHandler(data []byte, userData interface{}, response *handlerResponse) {
 	echo := Echo{}
 	json.Unmarshal(data, &echo)
 
+	fmt.Fprintf(os.Stderr, "=== input %s\n", echo.Arg)
 	response.AddResult("result", echo.Arg)
 }
 
@@ -177,63 +129,53 @@ func returnErrorHandler(data []byte, userData interface{}, response *handlerResp
 	response.SetErrorMsg("This is an error")
 }
 
-func returnDataErrorHandler(data []byte, userData interface{}, response *handlerResponse) {
-	response.AddResult("foo", "bar")
-	response.SetErrorMsg("This is an error")
-}
-
 func TestProtocol(t *testing.T) {
 	tests := []struct {
-		input, output string
+		cmd   api.Command
+		input string
+
+		result bool
+		output string
 	}{
-		{`{"id": "simple"}`, `{"success":true}`},
-		{`{"id": "notfound"}`,
-			`{"success":false,"error":"no payload named 'notfound'"}`},
-		{`{"foo": "bar"}`,
-			`{"success":false,"error":"no 'id' field in request"}`},
+		{api.Command(0), "", true, ""},
 		// Tests return values from handlers
-		{`{"id":"returnData", "data": {"arg": "bar"}}`,
-			`{"success":true,"data":{"foo":"bar"}}`},
-		{`{"id":"returnError" }`,
-			`{"success":false,"error":"This is an error"}`},
-		{`{"id":"returnDataError", "data": {"arg": "bar"}}`,
-			`{"success":false,"error":"This is an error","data":{"foo":"bar"}}`},
+		{api.Command(1), `{"arg": "bar"}`, true, `{"foo":"bar"}`},
+		{api.Command(2), "", false, `{"msg":"This is an error"}`},
 		// Tests we can unmarshal payload data
-		{`{"id":"echo", "data": {"arg": "ping"}}`,
-			`{"success":true,"data":{"result":"ping"}}`},
+		{api.Command(3), `{"arg": "ping"}`, true, `{"result":"ping"}`},
 	}
 
 	proto := newProtocol()
-	proto.Handle("simple", simpleHandler)
-	proto.Handle("returnData", returnDataHandler)
-	proto.Handle("returnError", returnErrorHandler)
-	proto.Handle("returnDataError", returnDataErrorHandler)
-	proto.Handle("echo", echoHandler)
+	proto.Handle(api.Command(0), simpleHandler)
+	proto.Handle(api.Command(1), returnDataHandler)
+	proto.Handle(api.Command(2), returnErrorHandler)
+	proto.Handle(api.Command(3), echoHandler)
 
 	client, _ := setupMockServer(t, proto)
 
 	for _, test := range tests {
 		// request
-		err := writeMessage(client, []byte(test.input))
+		err := api.WriteCommand(client, test.cmd, []byte(test.input))
 		assert.Nil(t, err)
 
 		// response
-		buf, err := readMessage(client)
+		frame, err := api.ReadFrame(client)
+		assert.Equal(t, frame.Header.InError, !test.result)
 		assert.Nil(t, err)
-		assert.Equal(t, test.output, string(buf))
+		assert.NotNil(t, frame)
+		assert.Equal(t, test.output, string(frame.Payload))
 	}
 }
 
 // Make sure the server closes the connection when encountering an error
 func TestCloseOnError(t *testing.T) {
 	proto := newProtocol()
-	proto.Handle("simple", simpleHandler)
+	proto.Handle(api.Command(0), simpleHandler)
 
 	client, _ := setupMockServer(t, proto)
 
-	// request
-	const garbage string = "sekjewr"
-	err := writeMessage(client, []byte(garbage))
+	// bad request
+	err := api.WriteCommand(client, api.Command(255), nil)
 	assert.Nil(t, err)
 
 	// response

--- a/proxy.go
+++ b/proxy.go
@@ -315,10 +315,10 @@ func (proxy *proxy) serve() {
 
 	// Define the client (runtime/shim) <-> proxy protocol
 	proto := newProtocol()
-	proto.Handle("register", registerVMHandler)
-	proto.Handle("attach", attachVMHandler)
-	proto.Handle("unregister", unregisterVMHandler)
-	proto.Handle("hyper", hyperHandler)
+	proto.Handle(api.CmdRegisterVM, registerVMHandler)
+	proto.Handle(api.CmdAttachVM, attachVMHandler)
+	proto.Handle(api.CmdUnregisterVM, unregisterVMHandler)
+	proto.Handle(api.CmdHyper, hyperHandler)
 
 	glog.V(1).Info("proxy started")
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Intel Corporation
+// Copyright (c) 2016,2017 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -206,7 +206,7 @@ const testContainerID = "0987654321"
 
 func TestRegisterVM(t *testing.T) {
 	proto := newProtocol()
-	proto.Handle("register", registerVMHandler)
+	proto.Handle(api.CmdRegisterVM, registerVMHandler)
 
 	rig := newTestRig(t, proto)
 	rig.Start()
@@ -242,8 +242,8 @@ func TestRegisterVM(t *testing.T) {
 
 func TestUnregisterVM(t *testing.T) {
 	proto := newProtocol()
-	proto.Handle("register", registerVMHandler)
-	proto.Handle("unregister", unregisterVMHandler)
+	proto.Handle(api.CmdRegisterVM, registerVMHandler)
+	proto.Handle(api.CmdUnregisterVM, unregisterVMHandler)
 
 	rig := newTestRig(t, proto)
 	rig.Start()
@@ -282,9 +282,9 @@ func TestUnregisterVM(t *testing.T) {
 
 func TestAttachVM(t *testing.T) {
 	proto := newProtocol()
-	proto.Handle("register", registerVMHandler)
-	proto.Handle("attach", attachVMHandler)
-	proto.Handle("unregister", unregisterVMHandler)
+	proto.Handle(api.CmdRegisterVM, registerVMHandler)
+	proto.Handle(api.CmdAttachVM, attachVMHandler)
+	proto.Handle(api.CmdUnregisterVM, unregisterVMHandler)
 
 	rig := newTestRig(t, proto)
 	rig.Start()
@@ -319,8 +319,8 @@ func TestAttachVM(t *testing.T) {
 
 func TestHyperPing(t *testing.T) {
 	proto := newProtocol()
-	proto.Handle("register", registerVMHandler)
-	proto.Handle("hyper", hyperHandler)
+	proto.Handle(api.CmdRegisterVM, registerVMHandler)
+	proto.Handle(api.CmdHyper, hyperHandler)
 
 	rig := newTestRig(t, proto)
 	rig.Start()
@@ -347,8 +347,8 @@ func TestHyperPing(t *testing.T) {
 
 func TestHyperStartpod(t *testing.T) {
 	proto := newProtocol()
-	proto.Handle("register", registerVMHandler)
-	proto.Handle("hyper", hyperHandler)
+	proto.Handle(api.CmdRegisterVM, registerVMHandler)
+	proto.Handle(api.CmdHyper, hyperHandler)
 
 	rig := newTestRig(t, proto)
 	rig.Start()


### PR DESCRIPTION
Store the header and payload in a single buffer, so that
the entire frame is written at a time.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>